### PR TITLE
Fix "Cannot visit UUIDTools::UUID" error

### DIFF
--- a/lib/activeuuid/uuid.rb
+++ b/lib/activeuuid/uuid.rb
@@ -18,6 +18,11 @@ end
 
 module Arel
   module Visitors
+    class DepthFirst < Arel::Visitors::Visitor
+      def visit_UUIDTools_UUID(o)
+        o.quoted_id
+      end
+    end
     class MySQL < Arel::Visitors::ToSql
       def visit_UUIDTools_UUID(o)
         o.quoted_id


### PR DESCRIPTION
Adding visit_UUIDTools_UUID method to DepthFirst class since Arel each method calls DepthFirst and not MySQL visitor.
