### PR TITLE
Generate uuid after initialize to support validations on id

### DIFF
--- a/lib/activeuuid/uuid.rb
+++ b/lib/activeuuid/uuid.rb
@@ -86,6 +86,7 @@ module ActiveUUID
 
       singleton_class.alias_method_chain :instantiate, :uuid
       before_create :generate_uuids_if_needed
+      after_initialize :generate_uuids_if_needed
     end
 
     module ClassMethods

--- a/spec/lib/activerecord_spec.rb
+++ b/spec/lib/activerecord_spec.rb
@@ -99,9 +99,13 @@ describe UuidArticle do
   context 'new record' do
     let!(:article) { Fabricate.build :uuid_article }
     subject { article }
+    let(:uuid) { UUIDTools::UUID.random_create }
+    let(:string) { uuid.to_s }
+    before { subject.another_uuid = string }
 
     context 'validation' do
       its(:id) { should be_nil }
+      its(:another_uuid) { should be_a UUIDTools::UUID  }
       specify { subject.should be_new_record }
       specify { subject.should be_valid }
     end

--- a/spec/support/models/uuid_article.rb
+++ b/spec/support/models/uuid_article.rb
@@ -1,6 +1,7 @@
 class UuidArticle < ActiveRecord::Base
   include ActiveUUID::UUID
 
-  validates :id, uniqueness: true, length: { in: 32..40 }, unless: :new_record?
+  validates :id, presence: true, uniqueness: true, length: { in: 32..40 }, unless: :new_record?
+  validates :another_uuid, presence: true, uniqueness: true, length: { in: 32..40 }, unless: :new_record?
 
 end


### PR DESCRIPTION
Generate the uuid during after_initialize instead of before_create as suggested in #6. This enables validation of `id` or other uuid attributes.
