### PR TITLE
Support for connection.add_column and connection.change_column

### DIFF
--- a/lib/activeuuid/patches.rb
+++ b/lib/activeuuid/patches.rb
@@ -1,3 +1,7 @@
+require 'active_record'
+require 'active_support/concern'
+
+
 module ActiveUUID
   module Patches
     module Migrations
@@ -48,6 +52,12 @@ module ActiveUUID
         alias_method_chain :type_cast, :visiting
       end
     end
+    
+    def self.update_native_database_types
+      if defined? ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter::NATIVE_DATABASE_TYPES
+        ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter::NATIVE_DATABASE_TYPES[:uuid] = { :name => 'binary', :limit => 16 }
+      end
+    end
 
     def self.apply!
       ActiveRecord::ConnectionAdapters::Table.send :include, Migrations if defined? ActiveRecord::ConnectionAdapters::Table
@@ -55,6 +65,7 @@ module ActiveUUID
       ActiveRecord::ConnectionAdapters::Mysql2Adapter.send :include, Quoting if defined? ActiveRecord::ConnectionAdapters::Mysql2Adapter
       ActiveRecord::ConnectionAdapters::SQLite3Adapter.send :include, Quoting if defined? ActiveRecord::ConnectionAdapters::SQLite3Adapter
       ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.send :include, PostgreSQLQuoting if defined? ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
+      self.update_native_database_types
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,4 +38,10 @@ RSpec.configure do |config|
   config.after(:each) do
     DatabaseCleaner.clean
   end
+  
+  def spec_for_adapter(&block)
+    switcher = ActiveUUID::SpecSupport::SpecForAdapter.new()
+    yield switcher
+    switcher.run(connection)
+  end
 end

--- a/spec/support/spec_for_adapter.rb
+++ b/spec/support/spec_for_adapter.rb
@@ -1,0 +1,20 @@
+require 'activeuuid'
+
+module ActiveUUID::SpecSupport
+  class SpecForAdapter
+    def initialize
+      @specs = {}
+    end
+    
+    [:sqlite, :mysql2, :postgres].each do |name|
+      send :define_method, name do |&block|
+        @specs[name] = block
+      end
+    end
+    
+    def run(connection)
+      name = connection.adapter_name.downcase.to_sym
+      @specs[name].call() if(@specs.include? name)
+    end
+  end
+end


### PR DESCRIPTION
This patch make it possible to use 'add_column' and 'change_column' in migration by defining a uuid column type in MySQL abstract adapter.

As a side change, I added an helper to use when the spec are not the same on every adapter. Hope it helps.

Might fix issue #4
