### PR TITLE
Sqlite3 compatibility fix

### DIFF
--- a/lib/activeuuid/patches.rb
+++ b/lib/activeuuid/patches.rb
@@ -29,7 +29,7 @@ module ActiveUUID
         end
 
         def simplified_type_with_uuid(field_type)
-          return :uuid if field_type == 'binary(16)'
+          return :uuid if field_type == 'binary(16)' || field_type == 'binary(16,0)'
           simplified_type_without_uuid(field_type)
         end
 


### PR DESCRIPTION
In some cases SQLite3 reports `binary(16,0)` as the column type instead of simply `binary(16)`
