### PR TITLE
Add UUIDTools::UUID#next method to avoid a bug with shoulda-matchers

### DIFF
--- a/lib/activeuuid/uuid.rb
+++ b/lib/activeuuid/uuid.rb
@@ -8,6 +8,10 @@ module UUIDTools
     # duck typing activerecord 3.1 dirty hack )
     def gsub *; self; end
 
+    def next
+      self.class.random_create
+    end
+
     def quoted_id
       s = raw.unpack("H*")[0]
       "x'#{s}'"

--- a/spec/lib/uuid_mokeypatch_spec.rb
+++ b/spec/lib/uuid_mokeypatch_spec.rb
@@ -12,6 +12,7 @@ describe UUIDTools::UUID do
     its(:quoted_id) {should == sql_out}
     its(:as_json) {should == hex}
     its(:to_param) {should == hex}
+    its(:next) {should be_a(described_class)}
   end
 
   describe '.serialize' do


### PR DESCRIPTION
My RSpec suite randomly fail because of a bug between `shoulda-matchers` and `activeuuid`:

Indeed Shoulda relies on Type#next to randomly change an ID, but UUID#next was not implemented and returned UUID.to_s.next, which is or isn't an UUID !

I've patched UUID class to provide a random (but good) UUID on #next.
