### PR TITLE
Adds support for the JDBC MySql adapter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ rvm:
   - 2.1.5
   - 2.2.0
   - rbx-2
+  - jruby
 
 gemfile:
   - Gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,3 +32,16 @@ matrix:
       gemfile: gemfiles/Gemfile.rails-3-1
     - rvm: 2.2.0
       gemfile: gemfiles/Gemfile.rails-3-2
+    - rvm: jruby
+      gemfile: gemfiles/Gemfile.rails-3-1
+      env: DB=postgresql
+    - rvm: jruby
+      gemfile: gemfiles/Gemfile.rails-3-2
+      env: DB=postgresql
+    - rvm: jruby
+      gemfile: gemfiles/Gemfile.rails-4-0
+      env: DB=postgresql
+    - rvm: jruby
+      gemfile: gemfiles/Gemfile.rails-4-1
+      env: DB=postgresql
+

--- a/activeuuid.gemspec
+++ b/activeuuid.gemspec
@@ -23,14 +23,15 @@ Gem::Specification.new do |s|
   s.add_development_dependency "database_cleaner"
   s.add_development_dependency "forgery"
   s.add_development_dependency "fabrication"
-  if RUBY_ENGINE == 'ruby'
-    s.add_development_dependency "sqlite3"
-    s.add_development_dependency "pg"
-    s.add_development_dependency "mysql2"
-  elsif RUBY_ENGINE == 'jruby'
+
+  if RUBY_ENGINE == 'jruby'
     s.add_development_dependency "activerecord-jdbcsqlite3-adapter"
     s.add_development_dependency "activerecord-jdbcpostgresql-adapter"
     s.add_development_dependency "activerecord-jdbcmysql-adapter"
+  else
+    s.add_development_dependency "sqlite3"
+    s.add_development_dependency "pg"
+    s.add_development_dependency "mysql2"
   end
 
   s.add_runtime_dependency "uuidtools"

--- a/activeuuid.gemspec
+++ b/activeuuid.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "fabrication"
   if RUBY_ENGINE == 'ruby'
     s.add_development_dependency "sqlite3"
-    # s.add_development_dependency "pg"
+    s.add_development_dependency "pg"
     s.add_development_dependency "mysql2"
   elsif RUBY_ENGINE == 'jruby'
     s.add_development_dependency "activerecord-jdbcsqlite3-adapter"

--- a/activeuuid.gemspec
+++ b/activeuuid.gemspec
@@ -23,9 +23,15 @@ Gem::Specification.new do |s|
   s.add_development_dependency "database_cleaner"
   s.add_development_dependency "forgery"
   s.add_development_dependency "fabrication"
-  s.add_development_dependency "sqlite3"
-  s.add_development_dependency "pg"
-  s.add_development_dependency "mysql2"
+  if RUBY_ENGINE == 'ruby'
+    s.add_development_dependency "sqlite3"
+    # s.add_development_dependency "pg"
+    s.add_development_dependency "mysql2"
+  elsif RUBY_ENGINE == 'jruby'
+    s.add_development_dependency "activerecord-jdbcsqlite3-adapter"
+    s.add_development_dependency "activerecord-jdbcpostgresql-adapter"
+    s.add_development_dependency "activerecord-jdbcmysql-adapter"
+  end
 
   s.add_runtime_dependency "uuidtools"
   s.add_runtime_dependency "activerecord", '>= 3.1'

--- a/lib/activeuuid/patches.rb
+++ b/lib/activeuuid/patches.rb
@@ -69,6 +69,32 @@ module ActiveUUID
       end
     end
 
+    module MysqlJdbcColumn
+      extend ActiveSupport::Concern
+
+      included do
+        # This is a really hacky solution, but it's the only way to support the
+        # MySql JDBC adapter without breaking backwards compatibility.
+        # It would be a lot easier if AR had support for custom defined types.
+        #
+        # Here's the path of execution:
+        # (1) JdbcColumn calls ActiveRecord::ConnectionAdapters::Column super constructor
+        # (2) super constructor calls simplified_type from MysqlJdbcColumn, since it's redefined here
+        # (3) if it's not a uuid, it calls original_simplified_type from ArJdbc::MySQL::Column module
+        # (4)   if there's no match ArJdbc::MySQL::Column calls super (ActiveUUID::Column.simplified_type_with_uuid)
+        # (5)     Since it's no a uuid (see step 3), simplified_type_without_uuid is called,
+        #         which maps to AR::ConnectionAdapters::Column.simplified_type (which has no super call, so we're good)
+        #
+        alias_method :original_simplified_type, :simplified_type
+
+        def simplified_type(field_type)
+          return :uuid if field_type == 'binary(16)' || field_type == 'binary(16,0)'
+          original_simplified_type(field_type)
+        end
+      end
+    end
+
+
     module PostgreSQLColumn
       extend ActiveSupport::Concern
 
@@ -162,7 +188,9 @@ module ActiveUUID
         ActiveRecord::ConnectionAdapters::Column.send :include, Column
         ActiveRecord::ConnectionAdapters::PostgreSQLColumn.send :include, PostgreSQLColumn if defined? ActiveRecord::ConnectionAdapters::PostgreSQLColumn
       end
+      ArJdbc::MySQL::Column.send :include, MysqlJdbcColumn if defined? ArJdbc::MySQL::Column
 
+      ActiveRecord::ConnectionAdapters::MysqlAdapter.send :include, Quoting if defined? ActiveRecord::ConnectionAdapters::MysqlAdapter
       ActiveRecord::ConnectionAdapters::Mysql2Adapter.send :include, Quoting if defined? ActiveRecord::ConnectionAdapters::Mysql2Adapter
       ActiveRecord::ConnectionAdapters::SQLite3Adapter.send :include, Quoting if defined? ActiveRecord::ConnectionAdapters::SQLite3Adapter
       ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.send :include, PostgreSQLQuoting if defined? ActiveRecord::ConnectionAdapters::PostgreSQLAdapter


### PR DESCRIPTION
This applies the necessary patches to specific MySql JDBC adapter classes.
It's been tested with both sqlite3 and mysql jdbc AR adapters (but not with Postgres).