### PR TITLE
Fix PostgreSQL array type casting(ArgumentError: wrong number of arguments (3 for 1..2))

### DIFF
--- a/lib/activeuuid/patches.rb
+++ b/lib/activeuuid/patches.rb
@@ -122,10 +122,10 @@ module ActiveUUID
           quote_without_visiting(value, column)
         end
 
-        def type_cast_with_visiting(value, column = nil)
+        def type_cast_with_visiting(value, column = nil, *args)
           value = UUIDTools::UUID.serialize(value) if column && column.type == :uuid
           value = value.to_s if value.is_a? UUIDTools::UUID
-          type_cast_without_visiting(value, column)
+          type_cast_without_visiting(value, column, *args)
         end
 
         def native_database_types_with_pguuid

--- a/spec/lib/activerecord_spec.rb
+++ b/spec/lib/activerecord_spec.rb
@@ -88,6 +88,18 @@ describe Article do
     its(:delete) { should be_truthy }
     its(:destroy) { should be_truthy }
   end
+
+  context '#save' do
+    subject { article }
+    let(:array) { [1, 2, 3] }
+    
+    its(:save) { should be_truthy }
+
+    context 'when change array field' do
+      before { article.some_array = array }
+      its(:save) { should be_truthy }      
+    end
+  end
 end
 
 describe UuidArticle do

--- a/spec/support/migrate/20141017204945_add_array_to_articles.rb
+++ b/spec/support/migrate/20141017204945_add_array_to_articles.rb
@@ -1,0 +1,5 @@
+class AddArrayToArticles < ActiveRecord::Migration
+  def change
+    add_column :articles, :some_array, :integer, array: true
+  end
+end


### PR DESCRIPTION
Hi, I've just faced up with an exception when saving model containing array field even without uuid.

```ruby
# Table name: users
#
#  id         :integer          not null, primary key
#  name       :string
#  some_array :integer          is an Array

u = User.first
u.some_array = [1,2,3]
u.save
ArgumentError: wrong number of arguments (3 for 1..2)
from /Users/donbobka/projects/streetbee/streetbee/.bundle/gems/activeuuid-0.5.0/lib/activeuuid/patches.rb:95:in `type_cast_with_visiting'
```

P.S.: Rails 4.1.6
P.P.S.: don't know about similar method `quote_with_visiting`