### PR TITLE
fix for Rails logger error

### DIFF
--- a/lib/activeuuid/uuid.rb
+++ b/lib/activeuuid/uuid.rb
@@ -36,6 +36,10 @@ module UUIDTools
       end
     end
 
+    def bytesize
+      16
+    end
+
   private
 
     def self.parse_string(str)


### PR DESCRIPTION
Rails logger always shows same error for models with ActiveUUID:
"Could not log "sql.active_record" event. NoMethodError: undefined method `bytesize'"

This small patch will fix it.