### PR TITLE
fix for rails 5

### DIFF
--- a/lib/activeuuid/patches.rb
+++ b/lib/activeuuid/patches.rb
@@ -1,7 +1,7 @@
 require 'active_record'
 require 'active_support/concern'
 
-if ActiveRecord::VERSION::MAJOR == 4 and ActiveRecord::VERSION::MINOR == 2
+if ActiveRecord::VERSION::MAJOR >= 4
   module ActiveRecord
     module Type
       class UUID < Binary # :nodoc:
@@ -181,7 +181,7 @@ module ActiveUUID
       ActiveRecord::ConnectionAdapters::Table.send :include, Migrations if defined? ActiveRecord::ConnectionAdapters::Table
       ActiveRecord::ConnectionAdapters::TableDefinition.send :include, Migrations if defined? ActiveRecord::ConnectionAdapters::TableDefinition
 
-      if ActiveRecord::VERSION::MAJOR == 4 and ActiveRecord::VERSION::MINOR == 2
+      if ActiveRecord::VERSION::MAJOR >= 4
         ActiveRecord::ConnectionAdapters::Mysql2Adapter.send :include, AbstractAdapter if defined? ActiveRecord::ConnectionAdapters::Mysql2Adapter
         ActiveRecord::ConnectionAdapters::SQLite3Adapter.send :include, AbstractAdapter if defined? ActiveRecord::ConnectionAdapters::SQLite3Adapter
       else


### PR DESCRIPTION
replaced `==` with `>=` when comparing `ActiveRecord::VERSION::MAJOR`

should resolve: https://github.com/jashmenn/activeuuid/issues/80 

ref: https://github.com/jashmenn/activeuuid/issues/46 
https://github.com/jashmenn/activeuuid/issues/39
