### PR TITLE
Skip parsing UUID when object not string

### DIFF
--- a/lib/activeuuid/patches.rb
+++ b/lib/activeuuid/patches.rb
@@ -174,6 +174,19 @@ module ActiveUUID
         end
 
         alias_method_chain :initialize_type_map, :uuid
+    end
+
+    module HasAndBelongsToManyAssociationPreloader
+      extend ActiveSupport::Concern
+
+      included do
+        def records_for_with_conversion(ids)
+          records_for_without_conversion(ids).each do |record|
+            record[association_key_name] = UUIDTools::UUID.parse_raw(record[association_key_name])
+          end
+        end
+
+        alias_method_chain :records_for, :conversion
       end
     end
 
@@ -194,6 +207,8 @@ module ActiveUUID
       ActiveRecord::ConnectionAdapters::Mysql2Adapter.send :include, Quoting if defined? ActiveRecord::ConnectionAdapters::Mysql2Adapter
       ActiveRecord::ConnectionAdapters::SQLite3Adapter.send :include, Quoting if defined? ActiveRecord::ConnectionAdapters::SQLite3Adapter
       ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.send :include, PostgreSQLQuoting if defined? ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
+
+      ActiveRecord::Associations::Preloader::HasAndBelongsToMany.send :include, HasAndBelongsToManyAssociationPreloader
     end
   end
 end

--- a/lib/activeuuid/patches.rb
+++ b/lib/activeuuid/patches.rb
@@ -209,7 +209,13 @@ module ActiveUUID
       ActiveRecord::ConnectionAdapters::SQLite3Adapter.send :include, Quoting if defined? ActiveRecord::ConnectionAdapters::SQLite3Adapter
       ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.send :include, PostgreSQLQuoting if defined? ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
 
-      ActiveRecord::Associations::Preloader::HasAndBelongsToMany.send :include, HasAndBelongsToManyAssociationPreloader
+      if Object.const_defined?("ActiveRecord::Associations::Preloader::HasAndBelongsToMany")
+        # works up to AR 4.0
+        ActiveRecord::Associations::Preloader::HasAndBelongsToMany.send :include, HasAndBelongsToManyAssociationPreloader
+      else
+        # starting in ActiveRecord 4.1
+        ActiveRecord::Associations::Preloader::BelongsTo.send :include, HasAndBelongsToManyAssociationPreloader
+      end
     end
   end
 end

--- a/lib/activeuuid/patches.rb
+++ b/lib/activeuuid/patches.rb
@@ -183,6 +183,7 @@ module ActiveUUID
       included do
         def records_for_with_conversion(ids)
           records_for_without_conversion(ids).each do |record|
+            next if record[association_key_name].is_a?(UUIDTools::UUID)
             record[association_key_name] = UUIDTools::UUID.parse_raw(record[association_key_name])
           end
         end

--- a/lib/activeuuid/patches.rb
+++ b/lib/activeuuid/patches.rb
@@ -174,6 +174,7 @@ module ActiveUUID
         end
 
         alias_method_chain :initialize_type_map, :uuid
+      end
     end
 
     module HasAndBelongsToManyAssociationPreloader

--- a/lib/activeuuid/uuid.rb
+++ b/lib/activeuuid/uuid.rb
@@ -83,7 +83,7 @@ module Arel
     end
 
     class WhereSql < Arel::Visitors::ToSql
-      def visit_UUIDTools_UUID(o)
+      def visit_UUIDTools_UUID(o, a = nil)
         o.quoted_id
       end
     end

--- a/lib/activeuuid/uuid.rb
+++ b/lib/activeuuid/uuid.rb
@@ -157,6 +157,7 @@ module ActiveUUID
 
     def generate_uuids_if_needed
       primary_key = self.class.primary_key
+      return true if self.class.columns_hash[primary_key].blank?
       if self.class.columns_hash[primary_key].type == :uuid
         send("#{primary_key}=", create_uuid) unless send("#{primary_key}?")
       end

--- a/lib/activeuuid/uuid.rb
+++ b/lib/activeuuid/uuid.rb
@@ -26,7 +26,7 @@ module UUIDTools
     end
 
     def to_param
-      to_s
+      hexdigest.upcase
     end
 
     # YAML.dump

--- a/lib/activeuuid/uuid.rb
+++ b/lib/activeuuid/uuid.rb
@@ -29,6 +29,11 @@ module UUIDTools
       to_s
     end
 
+    # YAML.dump
+    def encode_with coder
+      coder.represent_scalar nil, self.to_s
+    end
+
     def ==(other)
       self.to_s == other.to_s
     end

--- a/lib/activeuuid/uuid.rb
+++ b/lib/activeuuid/uuid.rb
@@ -29,6 +29,10 @@ module UUIDTools
       to_s
     end
 
+    def ==(other)
+      self.to_s == other.to_s
+    end
+
     def self.serialize(value)
       case value
       when self

--- a/lib/activeuuid/version.rb
+++ b/lib/activeuuid/version.rb
@@ -1,3 +1,3 @@
 module Activeuuid
-  VERSION = "0.5.1.b3f"
+  VERSION = "0.5.1.b40"
 end

--- a/lib/activeuuid/version.rb
+++ b/lib/activeuuid/version.rb
@@ -1,3 +1,3 @@
 module Activeuuid
-  VERSION = "0.5.2.b40"
+  VERSION = "0.5.3.b40"
 end

--- a/lib/activeuuid/version.rb
+++ b/lib/activeuuid/version.rb
@@ -1,3 +1,3 @@
 module Activeuuid
-  VERSION = "0.5.1.b40"
+  VERSION = "0.5.2.b40"
 end

--- a/lib/activeuuid/version.rb
+++ b/lib/activeuuid/version.rb
@@ -1,3 +1,3 @@
 module Activeuuid
-  VERSION = '0.6.1'
+  VERSION = "0.5.1.b3f"
 end


### PR DESCRIPTION
this avoids a ```     TypeError:
       Expected String, got UUIDTools::UUID instead.
```